### PR TITLE
update for 5/2021

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 **/.*.swp
 
 version.json
+libcudnn7_7.6.5.32-1+cuda10.2_amd64.deb

--- a/Dockerfile.gpu
+++ b/Dockerfile.gpu
@@ -1,6 +1,6 @@
 FROM nvidia/cuda:10.0-cudnn7-runtime-ubuntu18.04
 
-ARG DEEPSPEECH_VERSION=0.7.4
+ARG DEEPSPEECH_VERSION=0.9.3
 
 RUN apt-get update && \
         apt-get install -y --no-install-recommends \
@@ -35,7 +35,7 @@ WORKDIR /home/ds
 
 RUN mkdir -p ${HOME}/lib/ ${HOME}/bin/ ${HOME}/data/models/ ${HOME}/src/ds-srv/
 
-RUN curl https://sh.rustup.rs -sSf | sh -s -- -y --default-toolchain stable
+RUN curl https://sh.rustup.rs -sSf | sh -s -- -y --default-toolchain 1.41.1
 
 RUN curl https://community-tc.services.mozilla.com/api/index/v1/task/project.deepspeech.deepspeech.native_client.v${DS_VER}.gpu/artifacts/public/native_client.tar.xz -sSL | xz -d | tar -C ${HOME}/lib/ -xf -
 

--- a/Dockerfile.gpu
+++ b/Dockerfile.gpu
@@ -1,4 +1,4 @@
-FROM nvidia/cuda:10.0-cudnn7-runtime-ubuntu18.04
+FROM nvidia/cuda:10.1-runtime-ubuntu18.04
 
 ARG DEEPSPEECH_VERSION=0.9.3
 
@@ -9,9 +9,20 @@ RUN apt-get update && \
         sudo \
         curl
 
+# Do the following, and commend out the next 3 lines of code if you need libcudnn
+# 1. Get the following by signing up for an Nvidia Developer account, then going to https://developer.nvidia.com/cudnn
+# 2. Click on "Download cuDDN"
+# 3. Read and Agree to the Software License Agreement
+# 4. Click on "Archived cuDNN Releases"
+# 5. Click on "Download cuDNN v7.6.5 (November 18th, 2019), for CUDA 10.2"
+# 6. Click on "cuDNN Runtime Library for Ubuntu18.04 (Deb)"
+# WORKDIR $HOME/libcudnn
+# COPY ./libcudnn7_7.6.5.32-1+cuda10.2_amd64.deb .
+# RUN dpkg -i libcudnn7_7.6.5.32-1+cuda10.2_amd64.deb
+
 RUN useradd -c 'ds-srv' -m -d /home/ds -s /bin/bash ds
 
-ENV CUDA_ROOT /usr/local/cuda-10.0/
+ENV CUDA_ROOT /usr/local/cuda-10.1
 ENV HOME /home/ds
 ENV DS_VER $DEEPSPEECH_VERSION
 ENV LD_LIBRARY_PATH $HOME/lib/:$CUDA_ROOT/lib64/:$LD_LIBRARY_PATH

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,0 +1,10 @@
+version: '3.2'
+services:
+  deepspeech_server:
+    runtime: nvidia
+    build:
+      context: .
+      dockerfile: Dockerfile.gpu
+    restart: always
+    ports:
+      - '8080:8080'


### PR DESCRIPTION
Made a `docker-compose.yaml` file for convenience while changing a few things.

1. Using DeepSpeech 0.9.3 which is the latest release
2. Replace rust stable latest with version 1.41.1 (which was the latest at the time of the Rust server code was written). This is to prevent the following compiler error:

```
...
   Compiling crossbeam-utils v0.7.2
   Compiling memoffset v0.5.6
   Compiling crossbeam-epoch v0.8.2
error[E0282]: type annotations needed
  --> /home/ds/.cargo/registry/src/github.com-1ecc6299db9ec823/sample-0.9.1/src/window.rs:73:41
   |
73 |         let v = phase.to_float_sample().to_sample() * PI_2;
   |                                         ^^^^^^^^^ cannot infer type for type parameter `S` declared on the associated function `to_sample`
   |
help: consider specifying the type argument in the method call
   |
73 |         let v = phase.to_float_sample().to_sample::<S>() * PI_2;
   |                                                  ^^^^^

error: aborting due to previous error

For more information about this error, try `rustc --explain E0282`.
error: could not compile `sample`

To learn more, run the command again with --verbose.
warning: build failed, waiting for other jobs to finish...
...
```